### PR TITLE
장바구니 페이지 모바일 반응형 UI 추가

### DIFF
--- a/src/pages/cart/components/CartItem.tsx
+++ b/src/pages/cart/components/CartItem.tsx
@@ -13,12 +13,12 @@ export function CartItem() {
           <XIcon className="text-muted" />
         </Button>
       </div>
-      <div className="flex items-center space-x-8">
+      <div className="flex flex-col space-y-5 sm:flex-row sm:space-x-8">
         <div className="flex-1 flex items-center space-x-5">
-          <div className="w-32 h-32">
+          <div className="flex-1 sm:flex-none sm:w-32 sm:h-32">
             <img className="w-full h-full rounded-lg" src="images/product1.png" />
           </div>
-          <div className="space-y-1">
+          <div className="flex-1 sm:flex-none space-y-1">
             <h3 className="text-sm font-medium">나이키 바람막이</h3>
             <p className="text-sm">나이키</p>
             <div className="flex items-center space-x-2">
@@ -27,11 +27,13 @@ export function CartItem() {
             </div>
           </div>
         </div>
-        <div className="w-24">
-          <Input className="text-center" type="number" value={1} />
-        </div>
-        <div className="w-40">
-          <p className="font-medium">50,000원</p>
+        <div className="flex items-center space-x-5">
+          <div className="flex-1 sm:flex-none sm:w-24">
+            <Input className="text-center" type="number" value={1} />
+          </div>
+          <div className="flex-1 sm:flex-none sm:w-40">
+            <p className="text-center text-lg font-medium">50,000원</p>
+          </div>
         </div>
       </div>
     </li>


### PR DESCRIPTION
Close #23 

### 작업내용
- 장바구니 목록 UI 모바일 반응형 처리

### 참고사항
- 기존 UI는 유지하되 화면이 깨지지 않도록 처리하였습니다

### 참고화면
<img width="250" alt="스크린샷 2024-03-27 오후 7 21 59" src="https://github.com/f-lab-edu/simple-e-commerce/assets/160239336/5e020895-7e93-4b47-856b-1d2ca0d1a4d2">
